### PR TITLE
Specify npm as the package ecosystem in dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"


### PR DESCRIPTION
This pull request includes a small change to the `.github/dependabot.yml` file. The change specifies the package ecosystem as "npm" for dependabot updates.