### PR TITLE
feat(portfolio): show sample data for first-time visitors

### DIFF
--- a/docs/plans/2026-05-05-dummy-portfolio-design.md
+++ b/docs/plans/2026-05-05-dummy-portfolio-design.md
@@ -1,0 +1,115 @@
+# Dummy Portfolio for First-Time Visitors — Design
+
+**Date:** 2026-05-05
+**Status:** Design validated; implementation pending.
+
+## Goal
+
+When a first-time visitor opens the Portfolio Tracker, render a curated 5-stock sample portfolio so the page isn't empty. Sample is purely illustrative — never written to localStorage. As soon as the user adds their first real holding, the sample disappears and never returns for that market.
+
+## Behavior
+
+Render the 5 sample holdings for the currently selected market when **both** of these are true:
+
+1. `holdings.length === 0` for the current market.
+2. The market-specific seen-flag is unset (`localStorage.stockpulse_portfolio_seen_${market}` ≠ `true`).
+
+The seen-flag is **set on the first successful Add Holding** — via the existing form OR via the CSV import flow. Once set, the sample never returns for that market, even if the user later wipes everything (the page falls through to the existing empty state).
+
+IN and US scopes are independent — each market has its own sample list and its own seen-flag.
+
+### Demo-mode rendering
+
+Page header and summary cards (Total Invested / Current Value / Total P&L / Day's P&L) compute against sample data — they look like real numbers. Allocation pie + legend, Holdings table, Risk Analysis, Optimize Portfolio, and Insights all render against `displayHoldings` and call their real APIs for the 5 sample symbols. The demo therefore looks fully functional with no extra branching.
+
+A small inline banner sits above the Holdings table:
+
+> *Showing sample portfolio. Add your first holding to start tracking your own.*
+
+The Delete button on each row is hidden for sample rows (gated on `h.isDemo`). Stock-name links to `/stock/SYMBOL` work as today.
+
+## Sample data
+
+Mostly green: 4 winners + 1 small loser per market. Buy dates spread across the past 6–18 months. Sample row shape matches a real holding plus an `isDemo: true` marker; ids are deterministic (`demo-${symbol}`) so they cannot collide with real `crypto.randomUUID()` ids.
+
+### Indian market
+
+| Symbol | Name | Qty | Buy Price | Buy Date |
+|---|---|---|---|---|
+| RELIANCE.NS | Reliance Industries | 50 | 1280.00 | 2025-01-15 |
+| TCS.NS | Tata Consultancy Services | 25 | 3450.00 | 2024-11-22 |
+| HDFCBANK.NS | HDFC Bank | 75 | 1620.00 | 2025-03-10 |
+| ITC.NS | ITC | 200 | 425.00 | 2025-04-18 |
+| BHARTIARTL.NS | Bharti Airtel | 60 | 1850.00 | 2025-02-05 |
+
+### US market
+
+| Symbol | Name | Qty | Buy Price | Buy Date |
+|---|---|---|---|---|
+| AAPL | Apple | 30 | 175.00 | 2024-09-12 |
+| MSFT | Microsoft | 20 | 380.00 | 2024-12-03 |
+| NVDA | NVIDIA | 15 | 110.00 | 2025-01-20 |
+| AMZN | Amazon | 25 | 220.00 | 2025-02-14 |
+| GOOGL | Alphabet | 20 | 195.00 | 2025-03-25 |
+
+## Architecture
+
+Frontend-only. No backend changes — sample symbols flow through the existing `/api/stocks/batch`, `/api/stocks/{sym}/overview`, and history endpoints. No new dependency.
+
+### New file
+
+```
+src/data/samplePortfolio.js
+```
+
+Exports:
+
+- `SAMPLE_HOLDINGS_IN` and `SAMPLE_HOLDINGS_US` (the two arrays above, each row with `isDemo: true`)
+- `getSampleHoldings(market)` — returns the right array
+- `SEEN_FLAG_KEY = (market) => \`stockpulse_portfolio_seen_${market}\``
+
+Pure data + tiny helpers — no React, no I/O.
+
+### Edits to `src/components/PortfolioPage.js`
+
+1. Import `getSampleHoldings` and `SEEN_FLAG_KEY`.
+2. State: `const [seen, setSeen] = useLocalStorage(SEEN_FLAG_KEY(market), false);`
+3. Compute via `useMemo`:
+
+   ```js
+   const isDemoMode = holdings.length === 0 && !seen;
+   const displayHoldings = isDemoMode ? getSampleHoldings(market) : holdings;
+   ```
+
+   Downstream sections (pie chart, summary cards, sort, table, Risk Analysis, Optimize, Insights) read `displayHoldings` instead of `holdings`.
+4. `handleAddHolding` sets the seen-flag (`setSeen(true)`) alongside `setHoldings(...)`.
+5. `handleImport` (CSV import callback from PR #212) sets the seen-flag too.
+6. Holdings table row: wrap the Delete button in `{!h.isDemo && (...)}`.
+7. Inline banner above the Holdings table, gated on `isDemoMode`:
+
+   ```jsx
+   {isDemoMode && (
+     <div className="text-xs px-3 py-2 bg-blue-50 text-blue-700 border border-blue-200 rounded-md mb-3">
+       Showing sample portfolio. Add your first holding to start tracking your own.
+     </div>
+   )}
+   ```
+
+No changes to `PortfolioImport.js`, `useLocalStorage`, the backend, or any other component.
+
+## Edge cases
+
+- **Market switch.** Toggling IN ↔ US swaps both `holdings` (existing behavior) and `seen` to the other market's slot. A user with real IN holdings who has never visited US will see the US sample on first switch — intended.
+- **CSV import "Replace all" with an empty result** is already prevented by the existing `disabled={valid.length === 0}` on the Replace button — no edge case to handle.
+- **Manual delete to zero.** With the seen-flag set, the page shows the existing empty state ("No holdings yet"), not the sample. Existing copy unchanged.
+- **`useLocalStorage` JSON storage.** The flag is `true` / `false` (boolean, JSON-encoded), so `!seen` evaluates correctly.
+- **Cross-tab updates** are not auto-synced — same as today for `holdings`. No regression.
+- **Sample id collisions** are impossible: `demo-${symbol}` is structurally distinct from `crypto.randomUUID()` output.
+
+## Out of scope (YAGNI)
+
+- A "Reset to demo" button or any way to bring the sample back after the flag is set.
+- Live-fetched buy prices that hold a deterministic green/red position regardless of market movement — buy prices are hardcoded; the daily P&L is whatever the market does.
+- A "Try the sample portfolio" landing CTA on the home page.
+- Banner i18n.
+- Unit tests (matching the rest of the codebase's manual-verification posture).

--- a/docs/plans/2026-05-05-dummy-portfolio-design.md
+++ b/docs/plans/2026-05-05-dummy-portfolio-design.md
@@ -1,7 +1,7 @@
 # Dummy Portfolio for First-Time Visitors — Design
 
 **Date:** 2026-05-05
-**Status:** Design validated; implementation pending.
+**Status:** Implemented in PR #213.
 
 ## Goal
 

--- a/src/components/PortfolioPage.js
+++ b/src/components/PortfolioPage.js
@@ -6,6 +6,7 @@ import { useMarket } from '../context/MarketContext';
 import Sparkline from './Sparkline';
 import { exportPortfolio } from '../utils/exportUtils';
 import PortfolioImport from './PortfolioImport';
+import { getSampleHoldings, SEEN_FLAG_KEY } from '../data/samplePortfolio';
 
 const formatNumber = (num) => {
   if (num == null || isNaN(num)) return '-';
@@ -132,7 +133,13 @@ const PieLegend = ({ holdings, liveData }) => {
 const PortfolioPage = () => {
   const { market } = useMarket();
   const [holdings, setHoldings] = useLocalStorage(`stockpulse_portfolio_${market}`, []);
+  const [seen, setSeen] = useLocalStorage(SEEN_FLAG_KEY(market), false);
   const [watchlist] = useLocalStorage(`stockpulse_watchlist_${market}`, []);
+  const isDemoMode = holdings.length === 0 && !seen;
+  const displayHoldings = useMemo(
+    () => (isDemoMode ? getSampleHoldings(market) : holdings),
+    [isDemoMode, market, holdings],
+  );
   const [liveData, setLiveData] = useState({});
   const [sparklineData, setSparklineData] = useState({});
   const [loading, setLoading] = useState(false);
@@ -212,8 +219,8 @@ const PortfolioPage = () => {
   }, []);
 
   useEffect(() => {
-    fetchLivePrices(holdings, watchlist);
-  }, [holdings, watchlist, fetchLivePrices]);
+    fetchLivePrices(displayHoldings, watchlist);
+  }, [displayHoldings, watchlist, fetchLivePrices]);
 
   useEffect(() => {
     setImportOpen(false);
@@ -225,7 +232,8 @@ const PortfolioPage = () => {
     } else {
       setHoldings((prev) => [...prev, ...newRows]);
     }
-  }, [setHoldings]);
+    if (newRows.length > 0) setSeen(true);
+  }, [setHoldings, setSeen]);
 
   // Search autocomplete
   useEffect(() => {
@@ -294,6 +302,7 @@ const PortfolioPage = () => {
       id: crypto.randomUUID(),
     };
     setHoldings((prev) => [...prev, newHolding]);
+    setSeen(true);
     setSelectedStock(null);
     setSearchQuery('');
     setBuyPrice('');
@@ -306,20 +315,20 @@ const PortfolioPage = () => {
   };
 
   // Summaries
-  const totalInvested = holdings.reduce((s, h) => s + h.buyPrice * h.quantity, 0);
-  const totalCurrent = holdings.reduce((s, h) => {
+  const totalInvested = displayHoldings.reduce((s, h) => s + h.buyPrice * h.quantity, 0);
+  const totalCurrent = displayHoldings.reduce((s, h) => {
     const price = liveData[h.symbol]?.price || h.buyPrice;
     return s + price * h.quantity;
   }, 0);
   const totalPL = totalCurrent - totalInvested;
   const totalPLPercent = totalInvested > 0 ? (totalPL / totalInvested) * 100 : 0;
-  const dayPL = holdings.reduce((s, h) => {
+  const dayPL = displayHoldings.reduce((s, h) => {
     const change = liveData[h.symbol]?.change || 0;
     return s + change * h.quantity;
   }, 0);
 
   // Sorted holdings
-  const sortedHoldings = [...holdings].sort((a, b) => {
+  const sortedHoldings = [...displayHoldings].sort((a, b) => {
     const priceA = liveData[a.symbol]?.price || a.buyPrice;
     const priceB = liveData[b.symbol]?.price || b.buyPrice;
     const valA = priceA * a.quantity;
@@ -440,7 +449,7 @@ const PortfolioPage = () => {
       </div>
 
       {/* Empty state */}
-      {holdings.length === 0 && (
+      {displayHoldings.length === 0 && (
         <div className="bg-white rounded-xl border border-gray-200 p-12 text-center shadow-sm">
           <div className="text-gray-300 text-5xl mb-4">
             <svg className="w-16 h-16 mx-auto" fill="none" stroke="currentColor" viewBox="0 0 24 24">
@@ -452,7 +461,7 @@ const PortfolioPage = () => {
         </div>
       )}
 
-      {holdings.length > 0 && (
+      {displayHoldings.length > 0 && (
         <>
           {/* Summary Cards */}
           <div className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 mb-6">
@@ -489,14 +498,20 @@ const PortfolioPage = () => {
           <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
             <div className="bg-white rounded-xl border border-gray-200 p-4 shadow-sm lg:col-span-1">
               <h2 className="text-sm font-semibold text-gray-700 mb-3">Allocation</h2>
-              <PieChart holdings={holdings} liveData={liveData} />
-              <PieLegend holdings={holdings} liveData={liveData} />
+              <PieChart holdings={displayHoldings} liveData={liveData} />
+              <PieLegend holdings={displayHoldings} liveData={liveData} />
             </div>
 
             {/* Sort + Holdings Table */}
             <div className="lg:col-span-2">
+              {isDemoMode && (
+                <div className="text-xs px-3 py-2 bg-blue-50 text-blue-700 border border-blue-200 rounded-md mb-3 leading-relaxed">
+                  <span className="font-semibold">Sample portfolio for preview only.</span>{' '}
+                  Add your first holding (or import a CSV) and this sample disappears — only your own holdings will be tracked from then on.
+                </div>
+              )}
               <div className="flex items-center justify-between mb-3">
-                <h2 className="text-sm font-semibold text-gray-700">Holdings ({holdings.length})</h2>
+                <h2 className="text-sm font-semibold text-gray-700">Holdings ({displayHoldings.length})</h2>
                 <div className="flex items-center gap-2">
                   <button
                     onClick={() => setImportOpen(true)}
@@ -618,15 +633,17 @@ const PortfolioPage = () => {
                               {alloc.toFixed(1)}%
                             </td>
                             <td className="px-3 py-3">
-                              <button
-                                onClick={() => handleDelete(h.id)}
-                                className="text-gray-400 hover:text-red-500 transition-colors focus:outline-none"
-                                title="Remove holding"
-                              >
-                                <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                  <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                                </svg>
-                              </button>
+                              {!h.isDemo && (
+                                <button
+                                  onClick={() => handleDelete(h.id)}
+                                  className="text-gray-400 hover:text-red-500 transition-colors focus:outline-none"
+                                  title="Remove holding"
+                                >
+                                  <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                    <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                                  </svg>
+                                </button>
+                              )}
                             </td>
                           </tr>
                         );
@@ -660,15 +677,17 @@ const PortfolioPage = () => {
                           </Link>
                           <div className="text-xs text-gray-400">{h.symbol}</div>
                         </div>
-                        <button
-                          onClick={() => handleDelete(h.id)}
-                          className="text-gray-400 hover:text-red-500 transition-colors focus:outline-none"
-                          title="Remove holding"
-                        >
-                          <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                            <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
-                          </svg>
-                        </button>
+                        {!h.isDemo && (
+                          <button
+                            onClick={() => handleDelete(h.id)}
+                            className="text-gray-400 hover:text-red-500 transition-colors focus:outline-none"
+                            title="Remove holding"
+                          >
+                            <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16" />
+                            </svg>
+                          </button>
+                        )}
                       </div>
                       {/* Sparkline */}
                       <div className="mb-3">
@@ -731,13 +750,13 @@ const PortfolioPage = () => {
 
       {/* ===== OPTIMIZE PORTFOLIO SECTION ===== */}
       {(() => {
-        const uniqueSymbols = [...new Set(holdings.map(h => h.symbol))];
+        const uniqueSymbols = [...new Set(displayHoldings.map(h => h.symbol))];
         if (uniqueSymbols.length < 2) return null;
         return (
           <OptimizePortfolio
             symbols={uniqueSymbols}
             totalInvested={totalInvested}
-            holdings={holdings}
+            holdings={displayHoldings}
             liveData={liveData}
             totalCurrent={totalCurrent}
           />
@@ -746,14 +765,14 @@ const PortfolioPage = () => {
 
       {/* ===== RISK ANALYSIS SECTION ===== */}
       {(() => {
-        const uniqueSymbols = [...new Set(holdings.map(h => h.symbol))];
+        const uniqueSymbols = [...new Set(displayHoldings.map(h => h.symbol))];
         if (uniqueSymbols.length < 2) return null;
         return <RiskAnalysis symbols={uniqueSymbols} />;
       })()}
 
       {/* ===== INSIGHTS SECTION (only when portfolio has data and prices loaded) ===== */}
-      {holdings.length > 0 && !loading && Object.keys(liveData).length > 0 && (
-        <PortfolioInsights holdings={holdings} liveData={liveData} watchlist={watchlist} />
+      {displayHoldings.length > 0 && !loading && Object.keys(liveData).length > 0 && (
+        <PortfolioInsights holdings={displayHoldings} liveData={liveData} watchlist={watchlist} />
       )}
 
       <PortfolioImport

--- a/src/components/PortfolioPage.js
+++ b/src/components/PortfolioPage.js
@@ -523,16 +523,18 @@ const PortfolioPage = () => {
                     </svg>
                     Import CSV
                   </button>
-                  <button
-                    onClick={() => exportPortfolio(holdings, liveData)}
-                    className="text-xs px-2.5 py-1 rounded-md bg-green-50 text-green-700 hover:bg-green-100 font-medium transition-colors focus:outline-none flex items-center gap-1"
-                    title="Export holdings to CSV"
-                  >
-                    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
-                    </svg>
-                    Export CSV
-                  </button>
+                  {!isDemoMode && (
+                    <button
+                      onClick={() => exportPortfolio(holdings, liveData)}
+                      className="text-xs px-2.5 py-1 rounded-md bg-green-50 text-green-700 hover:bg-green-100 font-medium transition-colors focus:outline-none flex items-center gap-1"
+                      title="Export holdings to CSV"
+                    >
+                      <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" />
+                      </svg>
+                      Export CSV
+                    </button>
+                  )}
                   <span className="text-xs text-gray-400">Sort:</span>
                   {[
                     { key: 'name', label: 'Name' },

--- a/src/data/samplePortfolio.js
+++ b/src/data/samplePortfolio.js
@@ -1,0 +1,22 @@
+export const SEEN_FLAG_KEY = (market) => `stockpulse_portfolio_seen_${market}`;
+
+const demoRow = (row) => ({ ...row, id: `demo-${row.symbol}`, isDemo: true });
+
+export const SAMPLE_HOLDINGS_IN = [
+  { symbol: 'RELIANCE.NS', name: 'Reliance Industries', quantity: 50, buyPrice: 1280.0, buyDate: '2025-01-15' },
+  { symbol: 'TCS.NS', name: 'Tata Consultancy Services', quantity: 25, buyPrice: 3450.0, buyDate: '2024-11-22' },
+  { symbol: 'HDFCBANK.NS', name: 'HDFC Bank', quantity: 75, buyPrice: 1620.0, buyDate: '2025-03-10' },
+  { symbol: 'ITC.NS', name: 'ITC', quantity: 200, buyPrice: 425.0, buyDate: '2025-04-18' },
+  { symbol: 'BHARTIARTL.NS', name: 'Bharti Airtel', quantity: 60, buyPrice: 1850.0, buyDate: '2025-02-05' },
+].map(demoRow);
+
+export const SAMPLE_HOLDINGS_US = [
+  { symbol: 'AAPL', name: 'Apple', quantity: 30, buyPrice: 175.0, buyDate: '2024-09-12' },
+  { symbol: 'MSFT', name: 'Microsoft', quantity: 20, buyPrice: 380.0, buyDate: '2024-12-03' },
+  { symbol: 'NVDA', name: 'NVIDIA', quantity: 15, buyPrice: 110.0, buyDate: '2025-01-20' },
+  { symbol: 'AMZN', name: 'Amazon', quantity: 25, buyPrice: 220.0, buyDate: '2025-02-14' },
+  { symbol: 'GOOGL', name: 'Alphabet', quantity: 20, buyPrice: 195.0, buyDate: '2025-03-25' },
+].map(demoRow);
+
+export const getSampleHoldings = (market) =>
+  market === 'us' ? SAMPLE_HOLDINGS_US : SAMPLE_HOLDINGS_IN;

--- a/src/data/samplePortfolio.js
+++ b/src/data/samplePortfolio.js
@@ -3,19 +3,19 @@ export const SEEN_FLAG_KEY = (market) => `stockpulse_portfolio_seen_${market}`;
 const demoRow = (row) => ({ ...row, id: `demo-${row.symbol}`, isDemo: true });
 
 export const SAMPLE_HOLDINGS_IN = [
-  { symbol: 'RELIANCE.NS', name: 'Reliance Industries', quantity: 50, buyPrice: 1280.0, buyDate: '2025-01-15' },
-  { symbol: 'TCS.NS', name: 'Tata Consultancy Services', quantity: 25, buyPrice: 3450.0, buyDate: '2024-11-22' },
-  { symbol: 'HDFCBANK.NS', name: 'HDFC Bank', quantity: 75, buyPrice: 1620.0, buyDate: '2025-03-10' },
-  { symbol: 'ITC.NS', name: 'ITC', quantity: 200, buyPrice: 425.0, buyDate: '2025-04-18' },
-  { symbol: 'BHARTIARTL.NS', name: 'Bharti Airtel', quantity: 60, buyPrice: 1850.0, buyDate: '2025-02-05' },
+  { symbol: 'RELIANCE.NS', name: 'Reliance Industries', quantity: 50, buyPrice: 1280, buyDate: '2025-01-15' },
+  { symbol: 'TCS.NS', name: 'Tata Consultancy Services', quantity: 25, buyPrice: 3450, buyDate: '2024-11-22' },
+  { symbol: 'HDFCBANK.NS', name: 'HDFC Bank', quantity: 75, buyPrice: 1620, buyDate: '2025-03-10' },
+  { symbol: 'ITC.NS', name: 'ITC', quantity: 200, buyPrice: 425, buyDate: '2025-04-18' },
+  { symbol: 'BHARTIARTL.NS', name: 'Bharti Airtel', quantity: 60, buyPrice: 1850, buyDate: '2025-02-05' },
 ].map(demoRow);
 
 export const SAMPLE_HOLDINGS_US = [
-  { symbol: 'AAPL', name: 'Apple', quantity: 30, buyPrice: 175.0, buyDate: '2024-09-12' },
-  { symbol: 'MSFT', name: 'Microsoft', quantity: 20, buyPrice: 380.0, buyDate: '2024-12-03' },
-  { symbol: 'NVDA', name: 'NVIDIA', quantity: 15, buyPrice: 110.0, buyDate: '2025-01-20' },
-  { symbol: 'AMZN', name: 'Amazon', quantity: 25, buyPrice: 220.0, buyDate: '2025-02-14' },
-  { symbol: 'GOOGL', name: 'Alphabet', quantity: 20, buyPrice: 195.0, buyDate: '2025-03-25' },
+  { symbol: 'AAPL', name: 'Apple', quantity: 30, buyPrice: 175, buyDate: '2024-09-12' },
+  { symbol: 'MSFT', name: 'Microsoft', quantity: 20, buyPrice: 380, buyDate: '2024-12-03' },
+  { symbol: 'NVDA', name: 'NVIDIA', quantity: 15, buyPrice: 110, buyDate: '2025-01-20' },
+  { symbol: 'AMZN', name: 'Amazon', quantity: 25, buyPrice: 220, buyDate: '2025-02-14' },
+  { symbol: 'GOOGL', name: 'Alphabet', quantity: 20, buyPrice: 195, buyDate: '2025-03-25' },
 ].map(demoRow);
 
 export const getSampleHoldings = (market) =>


### PR DESCRIPTION
## Summary

Render a curated 5-stock sample portfolio when a user opens the Portfolio Tracker for the first time in a given market, so the page demonstrates the full feature set instead of showing an empty state. As soon as the user adds their own holding (via the form or CSV import), the sample disappears and never returns for that market.

- **Trigger**: `holdings.length === 0` AND market-specific seen-flag (`stockpulse_portfolio_seen_${market}`) is unset.
- **Sample data** lives in `src/data/samplePortfolio.js` — 5 IN large-caps (RELIANCE, TCS, HDFCBANK, ITC, BHARTIARTL) and 5 US ones (AAPL, MSFT, NVDA, AMZN, GOOGL). Mostly-green buy prices for a cheerful first impression. `isDemo: true` flag and deterministic `demo-${symbol}` ids.
- **Storage**: nothing written to localStorage in demo mode. Sample symbols flow through the existing `/api/stocks/batch` and per-symbol endpoints, so live prices, allocation pie, P&L, Risk Analysis, Optimize Portfolio, and Insights all render normally.
- **CRUD**: Delete button is hidden on sample rows; stock-name links still work. Add Holding form and CSV import both set the seen-flag on first success.
- **Sticky**: once the seen-flag is set, deleting all real holdings shows the existing empty state — sample does not reappear (intentional; matches "first-time" semantics).
- **Inline banner** above the Holdings table while in demo mode: *"Sample portfolio for preview only. Add your first holding (or import a CSV) and this sample disappears — only your own holdings will be tracked from then on."*
- **Independent per market**: IN seen-flag does not affect US.

Design doc: `docs/plans/2026-05-05-dummy-portfolio-design.md`.

## Test plan

For a clean test, clear `stockpulse_portfolio_IN`, `stockpulse_portfolio_US`, `stockpulse_portfolio_seen_IN`, and `stockpulse_portfolio_seen_US` from localStorage, then reload `/portfolio`.

- [ ] **Demo on IN** — 5 sample stocks render with banner, summary cards populated, pie chart non-empty, Risk Analysis + Optimize + Insights all visible.
- [ ] **Toggle to US** — different 5-stock sample (FAANG-ish), independent state.
- [ ] **Stock-name link** — clicking a sample row's stock name navigates to `/stock/SYMBOL` and the detail page loads.
- [ ] **No Delete on sample rows** — desktop and mobile views; Delete is absent.
- [ ] **Add a real holding** — sample disappears, banner gone, only the new row shows. `stockpulse_portfolio_seen_<market>` is now `true` in localStorage.
- [ ] **Delete all real holdings** — empty state ("No holdings yet."), **not** the sample.
- [ ] **Reload** — empty state persists, sample does not reappear.
- [ ] **CSV import on a fresh market** — successful import also sets the seen-flag and replaces the sample.
- [ ] **Independence** — set the IN seen-flag (by adding a holding), then check US is still in demo mode.
- [ ] `npm run build` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)